### PR TITLE
change sign and verify to common package

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -1,0 +1,22 @@
+package crypto
+
+import (
+	"github.com/gogo/protobuf/proto"
+	ic "github.com/libp2p/go-libp2p-core/crypto"
+)
+
+func Sign(key ic.PrivKey, channelMessage proto.Message) ([]byte, error) {
+	raw, err := proto.Marshal(channelMessage)
+	if err != nil {
+		return nil, err
+	}
+	return key.Sign(raw)
+}
+
+func Verify(key ic.PubKey, channelMessage proto.Message, sig []byte) (bool, error) {
+	raw, err := proto.Marshal(channelMessage)
+	if err != nil {
+		return false, err
+	}
+	return key.Verify(raw, sig)
+}

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -136,18 +136,4 @@ func CloseChannel(ctx context.Context, ledgerClient ledgerPb.ChannelsClient, sig
 	return nil
 }
 
-func Sign(key ic.PrivKey, channelMessage proto.Message) ([]byte, error) {
-	raw, err := proto.Marshal(channelMessage)
-	if err != nil {
-		return nil, err
-	}
-	return key.Sign(raw)
-}
 
-func Verify(key ic.PubKey, channelMessage proto.Message, sig []byte) (bool, error) {
-	raw, err := proto.Marshal(channelMessage)
-	if err != nil {
-		return false, err
-	}
-	return key.Verify(raw, sig)
-}


### PR DESCRIPTION
Extract Sign and Verify to more commonly used package
They shouldn't belong to only ledger specific.