### PR TITLE
BTFS-1159 new docker-compose to run go test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ ENV PROTOTOOL_VERSION=1.9.0
 
 # Install patch
 RUN apt-get update && apt-get install -y patch
-
-RUN apt-get install -y unzip
+RUN apt-get install -y unzip 
+RUN apt-get install -y postgresql-client redis-tools
 
 # install standard c++ implementation of protocol buffers
 RUN wget --quiet https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip

--- a/Makefile
+++ b/Makefile
@@ -62,15 +62,14 @@ test:
 	brew services start redis
 	dropdb --if-exists $(TEST_DB_NAME)
 	createdb $(TEST_DB_NAME)
-	go test -v ./... -args -db_url=$(TEST_DB_URL) -rd_url=$(TEST_RD_URL)
+	TEST_DB_URL=$(TEST_DB_URL); TEST_RD_URL=$(TEST_RD_URL); go test -v ./...
 	dropdb $(TEST_DB_NAME)
 	brew services stop postgresql
 	brew services stop redis
 
 test_docker:
 	sleep 10
-	go test -v ./... -args -db_url=$(TEST_DB_URL) -rd_url=$(DOCKER_TEST_RD_URL)
-	dropdb $(TEST_DB_NAME)
+	TEST_DB_URL=$(TEST_DB_URL); TEST_RD_URL=$(DOCKER_TEST_RD_URL); go test -v ./...
 
 test_git_diff_protos: 
 	bin/test-git-diff-protos

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,14 @@ default: lintf
 TEST_DB_NAME ?= runtime
 TEST_DB_USER ?= `whoami`
 TEST_DB_HOSTNAME ?= localhost
-TEST_DB_URL="postgresql://$(TEST_DB_USER)@$(TEST_DB_HOSTNAME):5432/$(TEST_DB_NAME)"
+TEST_DB_PORT ?= 5432
+TEST_DB_URL="postgresql://$(TEST_DB_USER)@$(TEST_DB_HOSTNAME):$(TEST_DB_PORT)/$(TEST_DB_NAME)"
 TEST_RD_NAME ?= runtime
 TEST_RD_USER ?= `whoami`
 TEST_RD_HOSTNAME ?= localhost
-TEST_RD_URL="redis://$(TEST_RD_USER)@$(TEST_RD_HOSTNAME):6379/$(TEST_RD_NAME)"
+TEST_RD_PORT ?= 6379
+TEST_RD_URL="redis://$(TEST_RD_USER)@$(TEST_RD_HOSTNAME):$(TEST_RD_PORT)/$(TEST_RD_NAME)"
+DOCKER_TEST_RD_URL="redis://$(TEST_RD_HOSTNAME):$(TEST_RD_PORT)"
 
 PG_FIX_CANDIDATES=./protos/node/node.pb.go \
 			./protos/status/status.pb.go \
@@ -63,6 +66,11 @@ test:
 	dropdb $(TEST_DB_NAME)
 	brew services stop postgresql
 	brew services stop redis
+
+test_docker:
+	sleep 10
+	go test -v ./... -args -db_url=$(TEST_DB_URL) -rd_url=$(DOCKER_TEST_RD_URL)
+	dropdb $(TEST_DB_NAME)
 
 test_git_diff_protos: 
 	bin/test-git-diff-protos

--- a/Makefile
+++ b/Makefile
@@ -62,14 +62,14 @@ test:
 	brew services start redis
 	dropdb --if-exists $(TEST_DB_NAME)
 	createdb $(TEST_DB_NAME)
-	TEST_DB_URL=$(TEST_DB_URL); TEST_RD_URL=$(TEST_RD_URL); go test -v ./...
+	TEST_DB_URL=$(TEST_DB_URL) TEST_RD_URL=$(TEST_RD_URL) go test -v ./...
 	dropdb $(TEST_DB_NAME)
 	brew services stop postgresql
 	brew services stop redis
 
 test_docker:
 	sleep 10
-	TEST_DB_URL=$(TEST_DB_URL); TEST_RD_URL=$(DOCKER_TEST_RD_URL); go test -v ./...
+	TEST_DB_URL=$(TEST_DB_URL) TEST_RD_URL=$(DOCKER_TEST_RD_URL) go test -v ./...
 
 test_git_diff_protos: 
 	bin/test-git-diff-protos

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3'
+services:
+  repo_test:
+    # runs go test on repo
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - 50051:50051
+    command:
+      bash -c "make test_docker"
+    depends_on:
+      - redis
+      - db
+    environment:
+      # set env vars that will work for docker-compose containers and Makefile
+      - TEST_DB_HOSTNAME=db
+      - TEST_DB_PORT=5432
+      - TEST_DB_USER=postgres
+      - TEST_RD_HOSTNAME=redis
+      - TEST_RD_PORT=6379
+  redis:
+    # spin up a redis db on 63790 port
+    image: redis
+    ports:
+      - 63790:6379
+  db:
+    # spin up postgres on 54320 port
+    image: postgres:latest
+    ports:
+      - 54320:5432
+    environment:
+      - POSTGRES_DB=runtime
+      - POSTGRES_USER=postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    ports:
-      - 50051:50051
     command:
       bash -c "make test_docker"
     depends_on:

--- a/utils/grpc/client_test.go
+++ b/utils/grpc/client_test.go
@@ -13,9 +13,9 @@ func TestNewGRPCConn(t *testing.T) {
 		out connectivity.State
 		err bool
 	}{
-		{in: "ftp://db-grpc-dev.btfs.io", err: true},
-		{in: "http://db-grpc-dev.btfs.io:443", err: true},
-		{in: "https://db-grpc-dev.btfs.io", out: connectivity.Ready},
+		{in: "ftp://status-dev.btfs.io", err: true},
+		{in: "http://status-dev.btfs.io:443", err: true},
+		{in: "https://status-dev.btfs.io", out: connectivity.Ready},
 	}
 	for _, tt := range tests {
 		ctx, cancelFunc := context.WithTimeout(context.Background(), 2*time.Second)

--- a/utils/runtime_test.go
+++ b/utils/runtime_test.go
@@ -2,7 +2,7 @@ package utils
 
 import (
 	"context"
-	"flag"
+	"os"
 	"testing"
 	"time"
 
@@ -13,19 +13,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var pgURLString *string
-var rdURLString *string
+var pgURLString string
+var rdURLString string
 
 func init() {
 	//get db and redis connection strings
-	pgURLString = flag.String("db_url", "xyz", "a string")
-	rdURLString = flag.String("rd_url", "xyz", "a string")
+	pgURLString = os.Getenv("TEST_DB_URL")
+	rdURLString = os.Getenv("TEST_RD_URL")
 }
 
 func TestCheckRuntimeDB(t *testing.T) {
 	//setup connection (postgres) object
 	var connection = db.ConnectionUrls{
-		PgURL: *pgURLString,
+		PgURL: pgURLString,
 		RdURL: "",
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -42,7 +42,7 @@ func TestCheckRuntimeRD(t *testing.T) {
 	//setup connection (redis) object
 	var connection = db.ConnectionUrls{
 		PgURL: "",
-		RdURL: *rdURLString,
+		RdURL: rdURLString,
 	}
 	shared := new(sharedpb.SignedRuntimeInfoRequest)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/utils/runtime_test.go
+++ b/utils/runtime_test.go
@@ -23,7 +23,7 @@ func init() {
 	//get db and redis connection strings
 	pgURLString, foundPgString = os.LookupEnv("TEST_DB_URL")
 	rdURLString, foundRdString = os.LookupEnv("TEST_RD_URL")
-	if(foundPgString == false || foundRdString == false){
+	if foundPgString == false || foundRdString == false {
 		panic(fmt.Sprintf("TEST_DB_URL and TEST_RD_URL env vars need to be set before running test"))
 	}
 }

--- a/utils/runtime_test.go
+++ b/utils/runtime_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -15,11 +16,16 @@ import (
 
 var pgURLString string
 var rdURLString string
+var foundPgString bool
+var foundRdString bool
 
 func init() {
 	//get db and redis connection strings
-	pgURLString = os.Getenv("TEST_DB_URL")
-	rdURLString = os.Getenv("TEST_RD_URL")
+	pgURLString, foundPgString = os.LookupEnv("TEST_DB_URL")
+	rdURLString, foundRdString = os.LookupEnv("TEST_RD_URL")
+	if(foundPgString == false || foundRdString == false){
+		panic(fmt.Sprintf("TEST_DB_URL and TEST_RD_URL env vars need to be set before running test"))
+	}
 }
 
 func TestCheckRuntimeDB(t *testing.T) {


### PR DESCRIPTION
- refactored Makefile to have dynamic ports for postgres and redis
- refactored how go test is run to not use -args because it causes the other unit tests to fail that do not use args.
- new make test_docker recipe to use docker-compose to set up postgres and redis and run `go test`
- fix client test_test to call the latest url of status server dev